### PR TITLE
Set timestamp from dynamic table entity if required

### DIFF
--- a/src/TableStorage.Abstractions.TableEntityConverters/EntityConvert.cs
+++ b/src/TableStorage.Abstractions.TableEntityConverters/EntityConvert.cs
@@ -97,6 +97,8 @@ namespace TableStorage.Abstractions.TableEntityConverters
 				rowProp.SetValue(o, convertRowKey(entity.RowKey));
 				properties.Remove(rowProp);
 			}
+
+			SetTimestamp(entity, o, properties);
 			FillProperties(entity, o, properties);
 			return o;
 		}
@@ -123,6 +125,30 @@ namespace TableStorage.Abstractions.TableEntityConverters
 			}
 
 			return name;
+		}
+
+		private static void SetTimestamp<T>(DynamicTableEntity entity, T o, List<PropertyInfo> properties) where T : new()
+		{
+			var timestampProperty = properties
+					.FirstOrDefault(p => p.Name == nameof(TableEntity.Timestamp));
+
+			if (timestampProperty != null)
+			{
+				if(timestampProperty.PropertyType == typeof(DateTimeOffset))
+				{
+					timestampProperty.SetValue(o, entity.Timestamp);
+				}
+
+				if (timestampProperty.PropertyType == typeof(DateTime))
+				{
+					timestampProperty.SetValue(o, entity.Timestamp.DateTime);
+				}
+
+				if (timestampProperty.PropertyType == typeof(string))
+				{
+					timestampProperty.SetValue(o, entity.Timestamp.ToString());
+				}
+			}
 		}
 
 		private static void FillProperties<T>(DynamicTableEntity entity, T o, List<PropertyInfo> properties) where T : new()

--- a/src/TableStorage.Abstractions.TableEntityConverters/EntityConvert.cs
+++ b/src/TableStorage.Abstractions.TableEntityConverters/EntityConvert.cs
@@ -130,7 +130,7 @@ namespace TableStorage.Abstractions.TableEntityConverters
 		private static void SetTimestamp<T>(DynamicTableEntity entity, T o, List<PropertyInfo> properties) where T : new()
 		{
 			var timestampProperty = properties
-					.FirstOrDefault(p => p.Name == nameof(TableEntity.Timestamp));
+					.FirstOrDefault(p => p.Name == nameof(DynamicTableEntity.Timestamp));
 
 			if (timestampProperty != null)
 			{

--- a/src/TableStorage.Abstractions.TableEntityConverters/EntityConvert.cs
+++ b/src/TableStorage.Abstractions.TableEntityConverters/EntityConvert.cs
@@ -155,10 +155,9 @@ namespace TableStorage.Abstractions.TableEntityConverters
 		{
 			foreach (var propertyInfo in properties)
 			{
-				if (entity.Properties.ContainsKey(propertyInfo.Name))
+				if (entity.Properties.ContainsKey(propertyInfo.Name) && propertyInfo.Name != nameof(DynamicTableEntity.Timestamp))
 				{
 					var val = entity.Properties[propertyInfo.Name].PropertyAsObject;
-
 
 					if (val != null && (propertyInfo.PropertyType == typeof(DateTimeOffset) || propertyInfo.PropertyType == typeof(DateTimeOffset?)))
 					{

--- a/src/TableStorage.Abstractions.UnitTests/Employee.cs
+++ b/src/TableStorage.Abstractions.UnitTests/Employee.cs
@@ -24,4 +24,14 @@ namespace TableStorage.Abstractions.UnitTests
 		public DateTime? ANullableDateTime { get; set; }
 		public int? ANullableInt { get; set; }
 	}
+
+	public class EmployeeWithTimestamp : Employee
+	{
+		public DateTimeOffset Timestamp { get; set; }
+	}
+
+	public class EmployeeWithTimestampAsString : Employee
+	{
+		public string Timestamp { get; set; }
+	}
 }

--- a/src/TableStorage.Abstractions.UnitTests/EntityConvertTests.cs
+++ b/src/TableStorage.Abstractions.UnitTests/EntityConvertTests.cs
@@ -36,6 +36,54 @@ namespace TableStorage.Abstractions.UnitTests
 		}
 
 		[Fact]
+		public void convert_from_entity_table_with_timestamp()
+		{
+			var emp = new Employee
+			{
+				Company = "Microsoft",
+				Name = "John Smith",
+				Department = new Department
+				{
+					Name = "QA",
+					Id = 1,
+					OptionalId = Guid.Parse("12ae85a4-7131-4e8c-af63-074b066412e0")
+				},
+				Id = 42,
+				ExternalId = Guid.Parse("e3bf64f4-0537-495c-b3bf-148259d7ed36"),
+				HireDate = DateTimeOffset.Parse("Thursday, January 31, 2008	")
+			};
+			var tableEntity = emp.ToTableEntity(e => e.Company, e => e.Id);
+			tableEntity.Timestamp = DateTime.UtcNow;
+			var employee = tableEntity.FromTableEntity<EmployeeWithTimestamp, string, int>(e => e.Company, e => e.Id);
+			Assert.Equal(Guid.Parse("12ae85a4-7131-4e8c-af63-074b066412e0"), employee.Department.OptionalId);
+			Assert.Equal(tableEntity.Timestamp, employee.Timestamp);
+		}
+
+		[Fact]
+		public void convert_from_entity_table_with_timestamp_as_string()
+		{
+			var emp = new Employee
+			{
+				Company = "Microsoft",
+				Name = "John Smith",
+				Department = new Department
+				{
+					Name = "QA",
+					Id = 1,
+					OptionalId = Guid.Parse("12ae85a4-7131-4e8c-af63-074b066412e0")
+				},
+				Id = 42,
+				ExternalId = Guid.Parse("e3bf64f4-0537-495c-b3bf-148259d7ed36"),
+				HireDate = DateTimeOffset.Parse("Thursday, January 31, 2008	")
+			};
+			var tableEntity = emp.ToTableEntity(e => e.Company, e => e.Id);
+			tableEntity.Timestamp = DateTime.UtcNow;
+			var employee = tableEntity.FromTableEntity<EmployeeWithTimestampAsString, string, int>(e => e.Company, e => e.Id);
+			Assert.Equal(Guid.Parse("12ae85a4-7131-4e8c-af63-074b066412e0"), employee.Department.OptionalId);
+			Assert.Equal(tableEntity.Timestamp.ToString(), employee.Timestamp);
+		}
+
+		[Fact]
 		public void convert_from_entity_table_complex_key()
 		{
 			var emp = new Employee

--- a/src/TableStorage.Abstractions.UnitTests/EntityConvertTests.cs
+++ b/src/TableStorage.Abstractions.UnitTests/EntityConvertTests.cs
@@ -38,8 +38,8 @@ namespace TableStorage.Abstractions.UnitTests
 		[Fact]
 		public void convert_from_entity_table_with_timestamp()
 		{
-			var emp = new Employee
-			{
+			var emp = new EmployeeWithTimestamp
+            {
 				Company = "Microsoft",
 				Name = "John Smith",
 				Department = new Department
@@ -62,8 +62,8 @@ namespace TableStorage.Abstractions.UnitTests
 		[Fact]
 		public void convert_from_entity_table_with_timestamp_as_string()
 		{
-			var emp = new Employee
-			{
+			var emp = new EmployeeWithTimestampAsString
+            {
 				Company = "Microsoft",
 				Name = "John Smith",
 				Department = new Department
@@ -283,7 +283,7 @@ namespace TableStorage.Abstractions.UnitTests
 			};
 			var tableEntity = emp.ToTableEntity(e => e.Company, e => e.Id);
 
-			Assert.Equal(true, tableEntity.Properties.ContainsKey("DepartmentJson"));
+			Assert.True(tableEntity.Properties.ContainsKey("DepartmentJson"));
 		}
 
 		[Fact]


### PR DESCRIPTION
Now if the system detects that a Timestamp property has been added to the POCO object, it automatically maps it to the Timestamp property available within the DynamicTableEntity.